### PR TITLE
Add plugin: .url WebView Opener

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17358,5 +17358,12 @@
     "author": "ZigHolding",
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
+  },
+  {
+    "id": "url-webview-opener",
+    "name": ".url WebView Opener",
+    "author": "Kieirra",
+    "description": "Opens .url files in Obsidian's internal webview.",
+    "repo": "Kieirra/obsidian-url-extension"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17363,7 +17363,7 @@
     "id": "url-webview-opener",
     "name": ".url WebView Opener",
     "author": "Kieirra",
-    "description": "Opens .url files in Obsidian's internal webview.",
+    "description": "Opens .url files in the internal webview.",
     "repo": "Kieirra/obsidian-url-extension"
   }
 ]


### PR DESCRIPTION
A lightweight and minimalist Obsidian plugin to view, open, and edit `.url` files directly in Obsidian’s native webview.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
